### PR TITLE
Throw correct errors for invalid keys

### DIFF
--- a/src/WeakMap.php
+++ b/src/WeakMap.php
@@ -45,6 +45,7 @@ if (! class_exists('WeakMap')) {
         public function offsetExists($object) : bool
         {
             $this->housekeeping();
+            $this->assertValidKey($object);
 
             $id = spl_object_id($object);
 
@@ -66,6 +67,7 @@ if (! class_exists('WeakMap')) {
         public function offsetGet($object)
         {
             $this->housekeeping();
+            $this->assertValidKey($object);
 
             $id = spl_object_id($object);
 
@@ -87,6 +89,7 @@ if (! class_exists('WeakMap')) {
         public function offsetSet($object, $value) : void
         {
             $this->housekeeping();
+            $this->assertValidKey($object);
 
             $id = spl_object_id($object);
 
@@ -97,6 +100,7 @@ if (! class_exists('WeakMap')) {
         public function offsetUnset($object) : void
         {
             $this->housekeeping();
+            $this->assertValidKey($object);
 
             $id = spl_object_id($object);
 
@@ -156,6 +160,17 @@ if (! class_exists('WeakMap')) {
                 }
 
                 $this->counter = 0;
+            }
+        }
+
+        private function assertValidKey($key) : void
+        {
+            if ($key === null) {
+                throw new Error('Cannot append to WeakMap');
+            }
+
+            if(!is_object($key)) {
+                throw new TypeError('WeakMap key must be an object');
             }
         }
     }

--- a/tests/WeakMapTest.php
+++ b/tests/WeakMapTest.php
@@ -206,6 +206,60 @@ class WeakMapTest extends TestCase
         self::assertNull($r->get());
     }
 
+    public function testKeyMustBeObjectToSet() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(TypeError::class);
+        self::expectExceptionMessage('WeakMap key must be an object');
+        $weakMap[1] = 2;
+    }
+
+    public function testKeyMustBeObjectToGet() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(TypeError::class);
+        self::expectExceptionMessage('WeakMap key must be an object');
+        $weakMap[1];
+    }
+
+    public function testKeyMustBeObjectToIsset() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(TypeError::class);
+        self::expectExceptionMessage('WeakMap key must be an object');
+        isset($weakMap[1]);
+    }
+
+    public function testKeyMustBeObjectToUnset() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(TypeError::class);
+        self::expectExceptionMessage('WeakMap key must be an object');
+        unset($weakMap[1]);
+    }
+
+    public function testCantAppend() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(Error::class);
+        self::expectExceptionMessage('Cannot append to WeakMap');
+        $weakMap[] = 1;
+    }
+
+    public function testCantDeepAppend() : void
+    {
+        $weakMap = new WeakMap();
+
+        self::expectException(Error::class);
+        self::expectExceptionMessage('Cannot append to WeakMap');
+        $weakMap[][1] = 1;
+    }
+
     /**
      * Similar to iterator_to_array(), but returns the result as a list of key-value pairs.
      * We need this, as iterator_to_array() on a WeakMap would fail because keys are objects.


### PR DESCRIPTION
Tests are based on the [specificaitons](https://github.com/php/php-src/blob/master/Zend/tests/weakrefs/weakmap_error_conditions.phpt).