### PR TITLE
Forbid serializing, setting dynamic property like native WeakMap

### DIFF
--- a/src/WeakMap.php
+++ b/src/WeakMap.php
@@ -136,6 +136,18 @@ if (! class_exists('WeakMap')) {
             $this->housekeepingCounter = 0;
         }
 
+        // NOTE: The native WeakMap does not implement this method,
+        // but does throw Error for setting dynamic properties.
+        public function __set($name, $value): void {
+            throw new Error("Cannot create dynamic property WeakMap::\$$name");
+        }
+
+        // NOTE: The native WeakMap does not implement this method,
+        // but does forbid serialization.
+        public function __serialize(): void {
+            throw new Exception("Serialization of 'WeakMap' is not allowed");
+        }
+
         private function housekeeping(bool $force = false) : void
         {
             if ($force || (++$this->housekeepingCounter === self::HOUSEKEEPING_EVERY)) {

--- a/tests/WeakMapTest.php
+++ b/tests/WeakMapTest.php
@@ -260,6 +260,22 @@ class WeakMapTest extends TestCase
         $weakMap[][1] = 1;
     }
 
+    public function testCantSetDynamicProperty() : void
+    {
+        $weakMap = new WeakMap();
+        self::expectException(Error::class);
+        self::expectExceptionMessage('Cannot create dynamic property WeakMap::$abc');
+        $weakMap->abc = 123;
+    }
+
+    public function testCantSerialize() : void
+    {
+        $weakMap = new WeakMap();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage("Serialization of 'WeakMap' is not allowed");
+        serialize($weakMap);
+    }
+
     /**
      * Similar to iterator_to_array(), but returns the result as a list of key-value pairs.
      * We need this, as iterator_to_array() on a WeakMap would fail because keys are objects.


### PR DESCRIPTION
The native `WeakMap::__unserialize` or `__wakeup` doesn't exist
and shouldn't be attempted other than by older uses of this polyfill.